### PR TITLE
Implemented sidebar and editor hiding depending on context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(imgui_minimal
   src/app.cpp
   src/node_editor.cpp
   src/ui_manager.cpp
+  src/sidebar.cpp
   src/renderer.cpp
   src/nodes.cpp
   src/link.cpp

--- a/include/app.h
+++ b/include/app.h
@@ -2,6 +2,7 @@
 #include "renderer.h"
 #include "ui_manager.h"
 #include "node_editor.h"
+#include "sidebar.h"
 #include <SDL.h>
 
 class App {
@@ -15,6 +16,7 @@ class App {
     Renderer renderer;
     UIManager ui_manager;
     NodeEditor node_editor;
+    Sidebar sidebar;
 
     bool initialize();
     void cleanup();

--- a/include/node_editor.h
+++ b/include/node_editor.h
@@ -3,6 +3,7 @@
 #include "imnodes.h"
 #include "nodes.h"
 #include "link.h"
+#include "sidebar.h"
 #include <vector>
 #include <memory>
 
@@ -13,9 +14,7 @@ class NodeEditor {
 
     bool initialize();
     void shutdown();
-    void render();
-
-    void showEditor(const char* window_title);
+    void render(const Sidebar& sidebar);
 
   private:
     std::vector<std::unique_ptr<Node>> nodes;

--- a/include/sidebar.h
+++ b/include/sidebar.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "imgui.h"
+
+class Sidebar {
+  public:
+    Sidebar();
+
+    void render();
+    static constexpr float SIDEBAR_WIDTH = 250.0f;
+};

--- a/include/sidebar.h
+++ b/include/sidebar.h
@@ -2,10 +2,26 @@
 
 #include "imgui.h"
 
+enum class ViewMode {
+  Projects,
+  Orchestrations
+};
+
 class Sidebar {
   public:
     Sidebar();
 
     void render();
+
+    int getCurrentProjectId() const { return current_project_id; }
+    int getCurrentOrchestrationId() const { return current_orchestration_id; }
+    ViewMode getCurrentViewMode() const { return current_view_mode; }
+
+    bool shouldShowNodeEditor() const;
+
     static constexpr float SIDEBAR_WIDTH = 250.0f;
+  private:
+    ViewMode current_view_mode = ViewMode::Projects;
+    int current_project_id = -1;
+    int current_orchestration_id = -1;
 };

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -57,10 +57,38 @@ void App::render() {
   renderer.clear();
 
   ui_manager.newFrame();
-
   sidebar.render();
 
-  node_editor.showEditor("Node Editor");
+  ImGuiIO& io = ImGui::GetIO();
+  ImGui::SetNextWindowPos(ImVec2(Sidebar::SIDEBAR_WIDTH, 0));
+  ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x - Sidebar::SIDEBAR_WIDTH, io.DisplaySize.y));
+
+  ImGui::Begin("Main Content", nullptr,
+      ImGuiWindowFlags_NoCollapse |
+      ImGuiWindowFlags_NoResize |
+      ImGuiWindowFlags_NoMove |
+      ImGuiWindowFlags_NoTitleBar);
+
+  if (!sidebar.shouldShowNodeEditor()) {
+    ImVec2 window_size = ImGui::GetWindowSize();
+    ImVec2 text_size;
+
+    if (sidebar.getCurrentViewMode() == ViewMode::Projects || sidebar.getCurrentProjectId() == -1) {
+      const char* message = "Open a project to start";
+      text_size = ImGui::CalcTextSize(message);
+      ImGui::SetCursorPos(ImVec2((window_size.x - text_size.x) * 0.5f, (window_size.y - text_size.y) * 0.5f));
+      ImGui::Text("%s", message);
+    } else {
+      const char* message = "Select or Create an orchestration to start";
+      text_size = ImGui::CalcTextSize(message);
+      ImGui::SetCursorPos(ImVec2((window_size.x - text_size.x) * 0.5f, (window_size.y - text_size.y) * 0.5f));
+      ImGui::Text("%s", message);
+    }
+  } else {
+    node_editor.render(sidebar);
+  }
+
+  ImGui::End();
 
   ui_manager.render();
   renderer.endFrame();

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -58,6 +58,8 @@ void App::render() {
 
   ui_manager.newFrame();
 
+  sidebar.render();
+
   node_editor.showEditor("Node Editor");
 
   ui_manager.render();

--- a/src/node_editor.cpp
+++ b/src/node_editor.cpp
@@ -1,6 +1,7 @@
 #include "node_editor.h"
 #include "nodes.h"
 #include "link.h"
+#include "sidebar.h"
 #include <cstring>
 #include <algorithm>
 #include <memory>
@@ -27,7 +28,13 @@ void NodeEditor::shutdown() {
   }
 }
 
-void NodeEditor::render() {
+void NodeEditor::render(const Sidebar& sidebar) {
+  if (!sidebar.shouldShowNodeEditor()) {
+    return;
+  }
+
+  int orchestration_id = sidebar.getCurrentOrchestrationId();
+
   ImNodes::BeginNodeEditor();
 
   drawNodes();
@@ -40,22 +47,6 @@ void NodeEditor::render() {
 
   createLinks();
   handleContextMenu();
-}
-
-void NodeEditor::showEditor(const char* window_title) {
-  ImGuiIO& io = ImGui::GetIO(); (void)io;
-  ImGui::SetNextWindowPos(ImVec2(0,0));
-  ImGui::SetNextWindowSize(io.DisplaySize);
-  ImGui::Begin(window_title, nullptr,
-      ImGuiWindowFlags_NoCollapse |
-      ImGuiWindowFlags_NoResize   |
-      ImGuiWindowFlags_NoMove     |
-      ImGuiWindowFlags_NoTitleBar |
-      ImGuiWindowFlags_NoBringToFrontOnFocus);
-  render();
-  ImGui::End();
-  deleteNodes();
-  deleteLinks();
 }
 
 void NodeEditor::createNode(const std::string& nodeType, ImVec2 position) {

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -1,0 +1,18 @@
+#include "sidebar.h"
+
+Sidebar::Sidebar() {}
+
+void Sidebar::render() {
+  ImGuiIO& io = ImGui::GetIO();
+
+  ImGui::SetNextWindowPos(ImVec2(0,0));
+  ImGui::SetNextWindowSize(ImVec2(SIDEBAR_WIDTH, io.DisplaySize.y));
+
+  ImGui::Begin("Sidebar", nullptr,
+      ImGuiWindowFlags_NoCollapse |
+      ImGuiWindowFlags_NoResize |
+      ImGuiWindowFlags_NoMove |
+      ImGuiWindowFlags_NoTitleBar);
+
+  ImGui::End();
+}

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -16,3 +16,9 @@ void Sidebar::render() {
 
   ImGui::End();
 }
+
+bool Sidebar::shouldShowNodeEditor() const {
+  return current_view_mode == ViewMode::Orchestrations &&
+    current_project_id != -1 &&
+    current_orchestration_id != -1;
+}


### PR DESCRIPTION
# Description

This PR introduces the Sidebar to the application layout and updates the rendering flow so that the main content adapts to the sidebar’s state.

## Images

<img width="1919" height="1075" alt="image" src="https://github.com/user-attachments/assets/1ab59c55-ec15-4f5e-8985-2c77e30f569a" />

## Key changes

### Sidebar

- Added Sidebar class with support for different view modes (Projects and Orchestrations).
- Implemented basic rendering of the sidebar with a fixed width (SIDEBAR_WIDTH).
- Added shouldShowNodeEditor() logic to determine if the Node Editor should be displayed.

### App

- Integrated Sidebar into the App class.
- Updated rendering flow: main content now shares screen space with the sidebar instead of rendering underneath it.
- Added default placeholder messages when no project or orchestration is selected.

### NodeEditor

- Changed render() to accept a Sidebar reference and only render nodes if a project and orchestration are selected.
- Removed old full-screen window duplication logic (showEditor now only opens the window).

#### Expected behavior

- The Node Editor only appears when both a project and orchestration are selected.
- When no content is loaded, default messages are displayed instead.
- The application layout now correctly allocates space for the sidebar, preventing overlap.

## Next steps

- Implement actual project and orchestration listing inside the sidebar.
- Add basic actions (create, delete, select projects/orchestrations).
- Integrate with a ProjectManager for persistence.