### PR TITLE
Add project and orchestration management to Sidebar with isolated data handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(imgui_minimal
   src/node_editor.cpp
   src/ui_manager.cpp
   src/sidebar.cpp
+  src/project.cpp
   src/renderer.cpp
   src/nodes.cpp
   src/link.cpp

--- a/include/app.h
+++ b/include/app.h
@@ -3,6 +3,7 @@
 #include "ui_manager.h"
 #include "node_editor.h"
 #include "sidebar.h"
+#include "project.h"
 #include <SDL.h>
 
 class App {
@@ -16,6 +17,7 @@ class App {
     Renderer renderer;
     UIManager ui_manager;
     NodeEditor node_editor;
+    ProjectManager project_manager;
     Sidebar sidebar;
 
     bool initialize();

--- a/include/node_editor.h
+++ b/include/node_editor.h
@@ -6,6 +6,14 @@
 #include "sidebar.h"
 #include <vector>
 #include <memory>
+#include <map>
+
+struct OrchestrationData {
+  std::vector<std::unique_ptr<Node>> nodes;
+  std::vector<std::unique_ptr<Link>> links;
+  int next_node_id = 1;
+  int next_link_id = 10000;
+};
 
 class NodeEditor {
   public:
@@ -17,22 +25,21 @@ class NodeEditor {
     void render(const Sidebar& sidebar);
 
   private:
-    std::vector<std::unique_ptr<Node>> nodes;
-    std::vector<std::unique_ptr<Link>> links;
+    std::map<int, std::unique_ptr<OrchestrationData>> orchestration_data;
     bool initialized = false;
-    int next_node_id = 1;
-    int next_link_id = 10000;
 
-    void handleContextMenu();
+    void handleContextMenu(OrchestrationData& data);
     void handleRightClick();
     ImVec2 context_menu_pos;
     bool right_clicked_in_editor = false;
 
-    void createNode(const std::string& nodeType, ImVec2 position);
-    void deleteNodes();
-    void drawNodes() const;
+    void createNode(const std::string& nodeType, ImVec2 position, OrchestrationData& data);
+    void deleteNodes(OrchestrationData& data);
+    void drawNodes(const OrchestrationData& data) const;
 
-    void createLinks();
-    void deleteLinks();
-    void drawLinks() const;
+    void createLinks(OrchestrationData& data);
+    void deleteLinks(OrchestrationData& data);
+    void drawLinks(const OrchestrationData& data) const;
+
+    OrchestrationData& getOrchestrationData(int orchestration_id);
 };

--- a/include/nodes.h
+++ b/include/nodes.h
@@ -7,7 +7,9 @@
 class Node {
 protected:
     int id;
+    int orchestration_id;
     std::string title;
+    ImVec2 position;
 
 public:
     Node(int nodeId, const std::string& nodeTitle);
@@ -16,6 +18,10 @@ public:
     virtual std::vector<int> getAttributeIds() const = 0;
     virtual void draw() = 0;
     int getId() const;
+
+    void setPosition(ImVec2 pos);
+    ImVec2 getPosition() const;
+    void updatePosition();
 };
 
 class StartNode : public Node {

--- a/include/project.h
+++ b/include/project.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <memory>
+
+class Orchestration {
+  public:
+    int id;
+    std::string name;
+
+    Orchestration(int id, const std::string& name);
+};
+
+class Project {
+  public:
+    int id;
+    std::string name;
+    std::vector<std::unique_ptr<Orchestration>> orchestrations;
+
+    Project(int id, const std::string& name);
+
+    void addOrchestration(const std::string& name);
+    Orchestration* getOrchestration(int orchestration_id);
+  private:
+    int next_orchestration_id = 1000;
+};
+
+class ProjectManager {
+  public:
+    ProjectManager();
+
+    void addProject(const std::string& name);
+    Project* getProject(int project_id);
+
+    const std::vector<std::unique_ptr<Project>>& getProjects() const { return projects; }
+
+  private:
+    std::vector<std::unique_ptr<Project>> projects;
+    int next_project_id = 1;
+};

--- a/include/project.h
+++ b/include/project.h
@@ -20,6 +20,7 @@ class Project {
     Project(int id, const std::string& name);
 
     void addOrchestration(const std::string& name);
+    void removeOrchestration(int orchestration_id);
     Orchestration* getOrchestration(int orchestration_id);
   private:
     int next_orchestration_id = 1000;
@@ -30,6 +31,7 @@ class ProjectManager {
     ProjectManager();
 
     void addProject(const std::string& name);
+    void removeProject(int project_id);
     Project* getProject(int project_id);
 
     const std::vector<std::unique_ptr<Project>>& getProjects() const { return projects; }

--- a/include/sidebar.h
+++ b/include/sidebar.h
@@ -28,6 +28,13 @@ class Sidebar {
     int current_project_id = -1;
     int current_orchestration_id = -1;
 
+    char new_project_name[256] = "";
+    char new_orchestration_name[256] = "";
+    bool show_create_project_popup = false;
+    bool show_create_orchestration_popup = false;
+
     void renderProjectsView();
     void renderOrchestrationsView();
+    void renderCreateProjectPopup();
+    void renderCreateOrchestrationPopup();
 };

--- a/include/sidebar.h
+++ b/include/sidebar.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "project.h"
 #include "imgui.h"
 
 enum class ViewMode {
@@ -9,7 +10,7 @@ enum class ViewMode {
 
 class Sidebar {
   public:
-    Sidebar();
+    Sidebar(ProjectManager& project_manager);
 
     void render();
 
@@ -20,8 +21,13 @@ class Sidebar {
     bool shouldShowNodeEditor() const;
 
     static constexpr float SIDEBAR_WIDTH = 250.0f;
+
   private:
+    ProjectManager& project_manager;
     ViewMode current_view_mode = ViewMode::Projects;
     int current_project_id = -1;
     int current_orchestration_id = -1;
+
+    void renderProjectsView();
+    void renderOrchestrationsView();
 };

--- a/include/sidebar.h
+++ b/include/sidebar.h
@@ -28,13 +28,18 @@ class Sidebar {
     int current_project_id = -1;
     int current_orchestration_id = -1;
 
+
     char new_project_name[256] = "";
     char new_orchestration_name[256] = "";
     bool show_create_project_popup = false;
     bool show_create_orchestration_popup = false;
+    int orchestration_to_delete = -1;
+    int project_to_delete = -1;
 
     void renderProjectsView();
     void renderOrchestrationsView();
     void renderCreateProjectPopup();
     void renderCreateOrchestrationPopup();
+    void renderDeleteOrchestrationConfirmation();
+    void renderDeleteProjectConfirmation();
 };

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,7 +1,7 @@
 #include "app.h"
 #include <stdio.h>
 
-App::App() {}
+App::App() : sidebar(project_manager) {}
 
 App::~App() {
   cleanup();
@@ -22,6 +22,11 @@ bool App::initialize() {
     printf("Failed to initialize node editor\n");
     return false;
   }
+
+  project_manager.addProject("Test project 1");
+  auto p = project_manager.getProject(1);
+  p->addOrchestration("Get Users");
+  project_manager.addProject("Test project 2");
 
   return true;
 }

--- a/src/node_editor.cpp
+++ b/src/node_editor.cpp
@@ -33,8 +33,6 @@ void NodeEditor::render(const Sidebar& sidebar) {
     return;
   }
 
-  int orchestration_id = sidebar.getCurrentOrchestrationId();
-
   ImNodes::BeginNodeEditor();
 
   drawNodes();

--- a/src/nodes.cpp
+++ b/src/nodes.cpp
@@ -3,11 +3,24 @@
 
 // -------------------- Base --------------------
 Node::Node(int nodeId, const std::string& nodeTitle)
-    : id(nodeId), title(nodeTitle) {}
+  : id(nodeId), title(nodeTitle), position(ImVec2(0, 0)) {}
 
 Node::~Node() {}
 
 int Node::getId() const { return id; }
+
+void Node::setPosition(ImVec2 pos) {
+  position = pos;
+  ImNodes::SetNodeGridSpacePos(id, position);
+}
+
+ImVec2 Node::getPosition() const {
+  return position;
+}
+
+void Node::updatePosition() {
+  position = ImNodes::GetNodeGridSpacePos(id);
+}
 
 // -------------------- StartNode --------------------
 StartNode::StartNode(int nodeId) : Node(nodeId, "Start") {}
@@ -15,23 +28,23 @@ StartNode::StartNode(int nodeId) : Node(nodeId, "Start") {}
 std::vector<int> StartNode::getAttributeIds() const { return {id + 1}; }
 
 void StartNode::draw() {
-    ImNodes::PushColorStyle(ImNodesCol_TitleBar, IM_COL32(200, 60, 60, 255));
-    ImNodes::PushColorStyle(ImNodesCol_TitleBarHovered, IM_COL32(220, 80, 80, 255));
-    ImNodes::PushColorStyle(ImNodesCol_TitleBarSelected, IM_COL32(180, 40, 40, 255));
-    ImNodes::BeginNode(id);
+  ImNodes::PushColorStyle(ImNodesCol_TitleBar, IM_COL32(200, 60, 60, 255));
+  ImNodes::PushColorStyle(ImNodesCol_TitleBarHovered, IM_COL32(220, 80, 80, 255));
+  ImNodes::PushColorStyle(ImNodesCol_TitleBarSelected, IM_COL32(180, 40, 40, 255));
+  ImNodes::BeginNode(id);
 
-      ImNodes::BeginNodeTitleBar();
-        ImGui::TextUnformatted(title.c_str());
-      ImNodes::EndNodeTitleBar();
+  ImNodes::BeginNodeTitleBar();
+  ImGui::TextUnformatted(title.c_str());
+  ImNodes::EndNodeTitleBar();
 
-      ImNodes::BeginOutputAttribute(id + 1);
-        ImGui::Text("Start ->");
-      ImNodes::EndOutputAttribute();
+  ImNodes::BeginOutputAttribute(id + 1);
+  ImGui::Text("Start ->");
+  ImNodes::EndOutputAttribute();
 
-    ImNodes::EndNode();
-    ImNodes::PopColorStyle();
-    ImNodes::PopColorStyle();
-    ImNodes::PopColorStyle();
+  ImNodes::EndNode();
+  ImNodes::PopColorStyle();
+  ImNodes::PopColorStyle();
+  ImNodes::PopColorStyle();
 }
 
 // -------------------- GetNode --------------------
@@ -40,27 +53,27 @@ GetNode::GetNode(int nodeId) : Node(nodeId, "GET") {}
 std::vector<int> GetNode::getAttributeIds() const { return {id + 1, id + 2}; }
 
 void GetNode::draw() {
-    ImNodes::PushColorStyle(ImNodesCol_TitleBar, IM_COL32(60, 180, 75, 255));
-    ImNodes::PushColorStyle(ImNodesCol_TitleBarHovered, IM_COL32(80, 200, 95, 255));
-    ImNodes::PushColorStyle(ImNodesCol_TitleBarSelected, IM_COL32(40, 160, 55, 255));
-    ImNodes::BeginNode(id);
+  ImNodes::PushColorStyle(ImNodesCol_TitleBar, IM_COL32(60, 180, 75, 255));
+  ImNodes::PushColorStyle(ImNodesCol_TitleBarHovered, IM_COL32(80, 200, 95, 255));
+  ImNodes::PushColorStyle(ImNodesCol_TitleBarSelected, IM_COL32(40, 160, 55, 255));
+  ImNodes::BeginNode(id);
 
-      ImNodes::BeginNodeTitleBar();
-        ImGui::TextUnformatted(title.c_str());
-      ImNodes::EndNodeTitleBar();
+  ImNodes::BeginNodeTitleBar();
+  ImGui::TextUnformatted(title.c_str());
+  ImNodes::EndNodeTitleBar();
 
-      ImNodes::BeginInputAttribute(id + 1);
-        ImGui::Text("URL");
-      ImNodes::EndInputAttribute();
+  ImNodes::BeginInputAttribute(id + 1);
+  ImGui::Text("URL");
+  ImNodes::EndInputAttribute();
 
-      ImNodes::BeginOutputAttribute(id + 2);
-        ImGui::Text("Response");
-      ImNodes::EndOutputAttribute();
+  ImNodes::BeginOutputAttribute(id + 2);
+  ImGui::Text("Response");
+  ImNodes::EndOutputAttribute();
 
-    ImNodes::EndNode();
-    ImNodes::PopColorStyle();
-    ImNodes::PopColorStyle();
-    ImNodes::PopColorStyle();
+  ImNodes::EndNode();
+  ImNodes::PopColorStyle();
+  ImNodes::PopColorStyle();
+  ImNodes::PopColorStyle();
 }
 
 
@@ -70,29 +83,29 @@ PostNode::PostNode(int nodeId) : Node(nodeId, "POST") {}
 std::vector<int> PostNode::getAttributeIds() const { return {id + 1, id + 2, id + 3}; }
 
 void PostNode::draw() {
-    ImNodes::PushColorStyle(ImNodesCol_TitleBar, IM_COL32(255, 200, 60, 255));
-    ImNodes::PushColorStyle(ImNodesCol_TitleBarHovered, IM_COL32(235, 180, 40, 255));
-    ImNodes::PushColorStyle(ImNodesCol_TitleBarSelected, IM_COL32(255, 220, 90, 255));
-    ImNodes::BeginNode(id);
+  ImNodes::PushColorStyle(ImNodesCol_TitleBar, IM_COL32(255, 200, 60, 255));
+  ImNodes::PushColorStyle(ImNodesCol_TitleBarHovered, IM_COL32(235, 180, 40, 255));
+  ImNodes::PushColorStyle(ImNodesCol_TitleBarSelected, IM_COL32(255, 220, 90, 255));
+  ImNodes::BeginNode(id);
 
-      ImNodes::BeginNodeTitleBar();
-        ImGui::TextUnformatted(title.c_str());
-      ImNodes::EndNodeTitleBar();
+  ImNodes::BeginNodeTitleBar();
+  ImGui::TextUnformatted(title.c_str());
+  ImNodes::EndNodeTitleBar();
 
-      ImNodes::BeginInputAttribute(id + 1);
-        ImGui::Text("URL");
-      ImNodes::EndInputAttribute();
+  ImNodes::BeginInputAttribute(id + 1);
+  ImGui::Text("URL");
+  ImNodes::EndInputAttribute();
 
-      ImNodes::BeginInputAttribute(id + 2);
-        ImGui::Text("Body");
-      ImNodes::EndInputAttribute();
+  ImNodes::BeginInputAttribute(id + 2);
+  ImGui::Text("Body");
+  ImNodes::EndInputAttribute();
 
-      ImNodes::BeginOutputAttribute(id + 3);
-        ImGui::Text("Response");
-      ImNodes::EndOutputAttribute();
+  ImNodes::BeginOutputAttribute(id + 3);
+  ImGui::Text("Response");
+  ImNodes::EndOutputAttribute();
 
-    ImNodes::EndNode();
-    ImNodes::PopColorStyle();
-    ImNodes::PopColorStyle();
-    ImNodes::PopColorStyle();
+  ImNodes::EndNode();
+  ImNodes::PopColorStyle();
+  ImNodes::PopColorStyle();
+  ImNodes::PopColorStyle();
 }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -5,21 +5,22 @@
 Orchestration::Orchestration(int id, const std::string& name)
   : id(id), name(name) {}
 
-// -------------------- Project --------------------
+  // -------------------- Project --------------------
 Project::Project(int id, const std::string& name)
   : id(id), name(name) {}
 
 void Project::addOrchestration(const std::string& name) {
-  orchestrations.push_back(std::make_unique<Orchestration>(next_orchestration_id++, name));
+  static int next_id = 1000;
+  orchestrations.push_back(std::make_unique<Orchestration>(next_id++, name));
 }
 
 void Project::removeOrchestration(int orchestration_id) {
   orchestrations.erase(
       std::remove_if(orchestrations.begin(), orchestrations.end(),
         [orchestration_id](const std::unique_ptr<Orchestration>& o) {
-          return o->id == orchestration_id;
+        return o->id == orchestration_id;
         }),
-        orchestrations.end()
+      orchestrations.end()
       );
 }
 
@@ -43,7 +44,7 @@ void ProjectManager::removeProject(int project_id) {
   projects.erase(
       std::remove_if(projects.begin(), projects.end(),
         [project_id](const std::unique_ptr<Project>& p) {
-          return p->id == project_id;
+        return p->id == project_id;
         }),
       projects.end()
       );

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -13,6 +13,16 @@ void Project::addOrchestration(const std::string& name) {
   orchestrations.push_back(std::make_unique<Orchestration>(next_orchestration_id++, name));
 }
 
+void Project::removeOrchestration(int orchestration_id) {
+  orchestrations.erase(
+      std::remove_if(orchestrations.begin(), orchestrations.end(),
+        [orchestration_id](const std::unique_ptr<Orchestration>& o) {
+          return o->id == orchestration_id;
+        }),
+        orchestrations.end()
+      );
+}
+
 Orchestration* Project::getOrchestration(int orchestration_id) {
   for(auto& orch : orchestrations) {
     if (orch->id == orchestration_id) {
@@ -27,6 +37,16 @@ ProjectManager::ProjectManager() {}
 
 void ProjectManager::addProject(const std::string& name) {
   projects.push_back(std::make_unique<Project>(next_project_id++, name));
+}
+
+void ProjectManager::removeProject(int project_id) {
+  projects.erase(
+      std::remove_if(projects.begin(), projects.end(),
+        [project_id](const std::unique_ptr<Project>& p) {
+          return p->id == project_id;
+        }),
+      projects.end()
+      );
 }
 
 Project* ProjectManager::getProject(int project_id) {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1,0 +1,41 @@
+#include "project.h"
+#include <algorithm>
+
+// -------------------- Orchestration --------------------
+Orchestration::Orchestration(int id, const std::string& name)
+  : id(id), name(name) {}
+
+// -------------------- Project --------------------
+Project::Project(int id, const std::string& name)
+  : id(id), name(name) {}
+
+void Project::addOrchestration(const std::string& name) {
+  orchestrations.push_back(std::make_unique<Orchestration>(next_orchestration_id++, name));
+}
+
+Orchestration* Project::getOrchestration(int orchestration_id) {
+  for(auto& orch : orchestrations) {
+    if (orch->id == orchestration_id) {
+      return orch.get();
+    }
+  }
+  return nullptr;
+}
+
+// -------------------- ProjectManager --------------------
+ProjectManager::ProjectManager() {}
+
+void ProjectManager::addProject(const std::string& name) {
+  projects.push_back(std::make_unique<Project>(next_project_id++, name));
+}
+
+Project* ProjectManager::getProject(int project_id) {
+  for(auto& proj : projects) {
+    if (proj->id == project_id) {
+      return proj.get();
+    }
+  }
+  return nullptr;
+}
+
+

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -53,8 +53,8 @@ void Sidebar::renderProjectsView() {
     float button_width = 20.0f;
     float available_width = ImGui::GetContentRegionAvail().x;
 
-    if (ImGui::Selectable(project->name.c_str(), current_project_id == project->id, 0 ,
-          ImVec2(available_width - button_width - ImGui::GetStyle().ItemSpacing.x, 0 ))) {
+    if (ImGui::Selectable(project->name.c_str(), current_project_id == project->id, 0,
+          ImVec2(available_width - button_width - ImGui::GetStyle().ItemSpacing.x, 0))) {
       current_project_id = project->id;
       current_orchestration_id = -1;
       current_view_mode = ViewMode::Orchestrations;
@@ -103,8 +103,8 @@ void Sidebar::renderOrchestrationsView() {
 
     bool is_selected = current_orchestration_id == orchestration->id;
 
-    if (ImGui::Selectable(orchestration->name.c_str(), is_selected, 0 ,
-          ImVec2(available_width - button_width - ImGui::GetStyle().ItemSpacing.x, 0 ))) {
+    if (ImGui::Selectable(orchestration->name.c_str(), is_selected, 0,
+          ImVec2(available_width - button_width - ImGui::GetStyle().ItemSpacing.x, 0))) {
       current_orchestration_id = orchestration->id;
     }
 

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -23,6 +23,9 @@ void Sidebar::render() {
   }
 
   ImGui::End();
+
+  renderCreateProjectPopup();
+  renderCreateOrchestrationPopup();
 }
 
 bool Sidebar::shouldShowNodeEditor() const {
@@ -35,7 +38,10 @@ void Sidebar::renderProjectsView() {
   ImGui::Text("Projects");
   ImGui::Separator();
 
-  if (ImGui::Button("Create New Project", ImVec2(-1, 0))) { }
+  if (ImGui::Button("Create New Project", ImVec2(-1, 0))) {
+    show_create_project_popup = true;
+    strcpy(new_project_name, "");
+  }
 
   ImGui::Spacing();
 
@@ -78,7 +84,10 @@ void Sidebar::renderOrchestrationsView() {
   ImGui::Text("Orchestrations");
   ImGui::Separator();
 
-  if (ImGui::Button("Create Orchestration", ImVec2(-1, 0))) { }
+  if (ImGui::Button("Create Orchestration", ImVec2(-1, 0))) {
+    show_create_orchestration_popup = true;
+    strcpy(new_orchestration_name, "");
+  }
 
   ImGui::Spacing();
 
@@ -100,5 +109,64 @@ void Sidebar::renderOrchestrationsView() {
     if (ImGui::Button("X", ImVec2(button_width, 0))) { }
     ImGui::PopStyleColor();
     ImGui::PopID();
+  }
+}
+
+void Sidebar::renderCreateProjectPopup() {
+  if (show_create_project_popup) {
+    ImGui::OpenPopup("Create Project");
+    show_create_project_popup = false;
+  }
+
+  if (ImGui::BeginPopupModal("Create Project", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::Text("Project Name:");
+    ImGui::InputText("##project_name", new_project_name, sizeof(new_project_name));
+
+    ImGui::Spacing();
+
+    if (ImGui::Button("Create")) {
+      if (strlen(new_project_name) > 0) {
+        project_manager.addProject(new_project_name);
+        ImGui::CloseCurrentPopup();
+      }
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel")) {
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
+  }
+}
+
+void Sidebar::renderCreateOrchestrationPopup() {
+  if (show_create_orchestration_popup) {
+    ImGui::OpenPopup("Create Orchestration");
+    show_create_orchestration_popup = false;
+  }
+
+  if (ImGui::BeginPopupModal("Create Orchestration", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::Text("Orchestration Name:");
+    ImGui::InputText("##orchestration_name", new_orchestration_name, sizeof(new_orchestration_name));
+
+    ImGui::Spacing();
+
+    if (ImGui::Button("Create")) {
+      if (strlen(new_orchestration_name) > 0) {
+        Project* current_project = project_manager.getProject(current_project_id);
+        if (current_project) {
+          current_project->addOrchestration(new_orchestration_name);
+        }
+        ImGui::CloseCurrentPopup();
+      }
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel")) {
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
   }
 }

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -26,6 +26,8 @@ void Sidebar::render() {
 
   renderCreateProjectPopup();
   renderCreateOrchestrationPopup();
+  renderDeleteOrchestrationConfirmation();
+  renderDeleteProjectConfirmation();
 }
 
 bool Sidebar::shouldShowNodeEditor() const {
@@ -60,7 +62,9 @@ void Sidebar::renderProjectsView() {
 
     ImGui::SameLine();
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.8f, 0.2f, 0.2f, 1.0f));
-    if (ImGui::Button("X", ImVec2(button_width, 0))) { }
+    if (ImGui::Button("X", ImVec2(button_width, 0))) {
+      project_to_delete = project->id;
+    }
     ImGui::PopStyleColor();
     ImGui::PopID();
   }
@@ -106,7 +110,9 @@ void Sidebar::renderOrchestrationsView() {
 
     ImGui::SameLine();
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.8f, 0.2f, 0.2f, 1.0f));
-    if (ImGui::Button("X", ImVec2(button_width, 0))) { }
+    if (ImGui::Button("X", ImVec2(button_width, 0))) {
+      orchestration_to_delete = orchestration->id;
+    }
     ImGui::PopStyleColor();
     ImGui::PopID();
   }
@@ -164,6 +170,68 @@ void Sidebar::renderCreateOrchestrationPopup() {
 
     ImGui::SameLine();
     if (ImGui::Button("Cancel")) {
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
+  }
+}
+
+void Sidebar::renderDeleteOrchestrationConfirmation() {
+  if (orchestration_to_delete != -1) {
+    ImGui::OpenPopup("Delete Orchestration");
+  }
+
+  if (ImGui::BeginPopupModal("Delete Orchestration", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::Text("Are you sure you want to delete this orchestration?");
+    ImGui::Spacing();
+
+    if (ImGui::Button("Yes")) {
+      Project* current_project = project_manager.getProject(current_project_id);
+      if (current_project) {
+        if (current_orchestration_id == orchestration_to_delete) {
+          current_orchestration_id = -1;
+        }
+        current_project->removeOrchestration(orchestration_to_delete);
+      }
+      orchestration_to_delete = -1;
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button("No")) {
+      orchestration_to_delete = -1;
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
+  }
+}
+
+void Sidebar::renderDeleteProjectConfirmation() {
+  if (project_to_delete != -1) {
+    ImGui::OpenPopup("Delete Project");
+  }
+
+  if (ImGui::BeginPopupModal("Delete Project", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::Text("Are you sure you want to delete this project?");
+    ImGui::Text("This will delete all orchestrations within it!");
+    ImGui::Spacing();
+
+    if (ImGui::Button("Yes")) {
+      if (current_project_id == project_to_delete) {
+        current_project_id = -1;
+        current_orchestration_id = -1;
+        current_view_mode = ViewMode::Projects;
+      }
+      project_manager.removeProject(project_to_delete);
+      project_to_delete = -1;
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button("No")) {
+      project_to_delete = -1;
       ImGui::CloseCurrentPopup();
     }
 

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -1,6 +1,8 @@
 #include "sidebar.h"
+#include <cstring>
 
-Sidebar::Sidebar() {}
+Sidebar::Sidebar(ProjectManager& project_manager)
+  : project_manager(project_manager) {}
 
 void Sidebar::render() {
   ImGuiIO& io = ImGui::GetIO();
@@ -14,6 +16,12 @@ void Sidebar::render() {
       ImGuiWindowFlags_NoMove |
       ImGuiWindowFlags_NoTitleBar);
 
+  if (current_view_mode == ViewMode::Projects) {
+    renderProjectsView();
+  } else {
+    renderOrchestrationsView();
+  }
+
   ImGui::End();
 }
 
@@ -21,4 +29,76 @@ bool Sidebar::shouldShowNodeEditor() const {
   return current_view_mode == ViewMode::Orchestrations &&
     current_project_id != -1 &&
     current_orchestration_id != -1;
+}
+
+void Sidebar::renderProjectsView() {
+  ImGui::Text("Projects");
+  ImGui::Separator();
+
+  if (ImGui::Button("Create New Project", ImVec2(-1, 0))) { }
+
+  ImGui::Spacing();
+
+  for (const auto& project : project_manager.getProjects()) {
+    ImGui::PushID(project->id);
+
+    float button_width = 20.0f;
+    float available_width = ImGui::GetContentRegionAvail().x;
+
+    if (ImGui::Selectable(project->name.c_str(), current_project_id == project->id, 0 ,
+          ImVec2(available_width - button_width - ImGui::GetStyle().ItemSpacing.x, 0 ))) {
+      current_project_id = project->id;
+      current_orchestration_id = -1;
+      current_view_mode = ViewMode::Orchestrations;
+    }
+
+    ImGui::SameLine();
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.8f, 0.2f, 0.2f, 1.0f));
+    if (ImGui::Button("X", ImVec2(button_width, 0))) { }
+    ImGui::PopStyleColor();
+    ImGui::PopID();
+  }
+}
+
+void Sidebar::renderOrchestrationsView() {
+  Project* current_project = project_manager.getProject(current_project_id);
+  if (!current_project) return;
+
+  if (ImGui::Button("<- Back to Projetcs")) {
+    current_view_mode = ViewMode::Projects;
+    current_project_id = -1;
+    current_orchestration_id = -1;
+    return;
+  }
+
+  ImGui::Spacing();
+  ImGui::Text("Project: %s", current_project->name.c_str());
+  ImGui::Separator();
+
+  ImGui::Text("Orchestrations");
+  ImGui::Separator();
+
+  if (ImGui::Button("Create Orchestration", ImVec2(-1, 0))) { }
+
+  ImGui::Spacing();
+
+  for (const auto& orchestration : current_project->orchestrations) {
+    ImGui::PushID(orchestration->id);
+
+    float button_width = 20.0f;
+    float available_width = ImGui::GetContentRegionAvail().x;
+
+    bool is_selected = current_orchestration_id == orchestration->id;
+
+    if (ImGui::Selectable(orchestration->name.c_str(), is_selected, 0 ,
+          ImVec2(available_width - button_width - ImGui::GetStyle().ItemSpacing.x, 0 ))) {
+      current_orchestration_id = orchestration->id;
+    }
+
+    ImGui::SameLine();
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.8f, 0.2f, 0.2f, 1.0f));
+    if (ImGui::Button("X", ImVec2(button_width, 0))) { }
+    ImGui::PopStyleColor();
+    ImGui::PopID();
+  }
 }


### PR DESCRIPTION
## Description

This PR expands the Sidebar and NodeEditor functionality to support projects and orchestrations with full create, select, and delete flows. It also introduces isolated orchestration data, so each orchestration manages its own nodes and links without leaking state.

## Images

| Projetcs | Orchestrations |
|---------|---------|
| <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/dc52e6d5-11f6-4b45-bac3-c7d7425de5eb" /> | <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/73571776-b457-4a21-918d-b59af8483255" /> |
| <img width="266" height="136" alt="image" src="https://github.com/user-attachments/assets/7ef1f0b2-5eeb-46c0-86f2-a537146113c9" />| <img width="269" height="139" alt="image" src="https://github.com/user-attachments/assets/9c32b2a4-794e-4138-aac4-589c02975697" /> |
| <img width="364" height="124" alt="image" src="https://github.com/user-attachments/assets/8e0c30c9-4929-4462-8b73-95345f04f0a1" /> | <img width="396" height="104" alt="image" src="https://github.com/user-attachments/assets/72cce1ce-c6a4-4a21-8ab5-c6f706c5000d" /> |

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/3e6ad5d2-3ab5-4193-89a7-9395a969492e" />



## Key changes

### **Sidebar**

* Renders available projects and orchestrations.
* Allows project selection → shows its orchestrations.
* Allows orchestration selection → displays it in the main content area.
* Added creation flows:
  * Create new project
  * Create new orchestration inside a project
* Added deletion flows:
  * Delete project (removes all its orchestrations)
  * Delete orchestration (removes only the selected orchestration)
* Confirmation modals for destructive actions.

### **Project system**

* Introduced `Project`, `Orchestration`, and `ProjectManager` classes.
* Each project can own multiple orchestrations.
* Each orchestration is uniquely identified and tied to its project.

### **NodeEditor**

* Now manages data **per orchestration**.
* Added `OrchestrationData` struct to store nodes, links, and ID counters.
* Node and link creation/deletion is scoped to the active orchestration.
* Removed old global handling where orchestrations shared data.

### **Nodes**

* Nodes now track their positions and can update them as users move them around.
* `Start`, `GET`, and `POST` nodes were updated to work with orchestration-specific IDs.

### **App**

* Integrated `ProjectManager` into the application.
* Sidebar is now constructed with a reference to `ProjectManager`.
* Added test initialization with sample projects and orchestrations.

---

#### Expected behavior

* The sidebar lists projects; selecting one shows its orchestrations.
* Selecting an orchestration displays its isolated NodeEditor canvas.
* Creating/deleting projects and orchestrations updates the sidebar dynamically.
* Each orchestration now maintains its own independent node graph.

---

### Next steps

* Persist projects/orchestrations across sessions.
* Add renaming support for projects and orchestrations.
* Start creating HttpClients so nodes can start to make requests
* Create more node types